### PR TITLE
Re-add ATLAS comment to installation.rst

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -48,10 +48,11 @@ The Linux distributions were built on Ubuntu 14.04, and so may not work on
 machines that have older versions of Linux system packages.  If these instructions
 do not work, then the executables will have to be built from source.
 
-1. Download the tar.gz archive for Linux and untar the folder to any directory
-2. Open a terminal window
-3. Navigate to the ``montreal-forced-aligner`` folder (``cd /path/to/montreal-forced-aligner``)
-4. Test the commands ``bin/mfa_align`` and ``bin/mfa_train_and_align`` (these should print usage messages about the commands)
+1. Ensure the ATLAS package is installed (``sudo apt-get install libatlas3-base``)
+2. Download the tar.gz archive for Linux and untar the folder to any directory
+3. Open a terminal window
+4. Navigate to the ``montreal-forced-aligner`` folder (``cd /path/to/montreal-forced-aligner``)
+5. Test the commands ``bin/mfa_align`` and ``bin/mfa_train_and_align`` (these should print usage messages about the commands)
 
 Building from source
 ====================


### PR DESCRIPTION
Reminder to install `libatlas3-base` got clobbered in a bad merge.