### PR TITLE
Fix an argument repeated error in a command

### DIFF
--- a/docs/source/example.rst
+++ b/docs/source/example.rst
@@ -61,7 +61,7 @@ phonetic transcription for each one of these words, which it will write to a fil
 
 .. code-block:: bash
 
-   bin/mfa_generate_dictionary /path/to/mandarin_pinyin_g2p.zip /path/to/examples/CH /path/to/examples/CH chinese_dict.txt
+   bin/mfa_generate_dictionary /path/to/mandarin_pinyin_g2p.zip /path/to/examples/CH chinese_dict.txt
 
 This should take no more than a few seconds. Open the output file, and check that all the words are there. The accuracy
 of the transcription should be near 100%. You can now use this to align your mini corpus:


### PR DESCRIPTION
`bin/mfa_generate_dictionary` command only has 3 positional arguments.