### PR TITLE
Fix char indexing

### DIFF
--- a/montreal_forced_aligner/dictionary.py
+++ b/montreal_forced_aligner/dictionary.py
@@ -32,7 +32,7 @@ brackets = [('[', ']'), ('{', '}'), ('<', '>'), ('(', ')')]
 
 def check_bracketed(word):
     for b in brackets:
-        if word[0] == b[0] and word[-1] == b[-1]:
+        if word.startswith(b[0]) and word.endswith(b[-1]):
             return True
     return False
 

--- a/tests/test_g2p.py
+++ b/tests/test_g2p.py
@@ -18,6 +18,7 @@ def test_clean_up_word():
 
 
 def test_check_bracketed():
+    """Checks if the brackets are removed correctly and handling an empty string works"""
     word_set = ['uh',  '(the)', 'sick', '<corpus>', '[a]', '{cold}', '']
     expected_result = ['uh', 'sick', '']
     assert [x for x in word_set if not check_bracketed(x)] == expected_result

--- a/tests/test_g2p.py
+++ b/tests/test_g2p.py
@@ -17,6 +17,12 @@ def test_clean_up_word():
     assert m == ['+']
 
 
+def test_check_bracketed():
+    word_set = ['uh',  '(the)', 'sick', '<corpus>', '[a]', '{cold}', '']
+    expected_result = ['uh', 'sick', '']
+    assert [x for x in word_set if not check_bracketed(x)] == expected_result
+
+
 def test_training(sick_dict, sick_g2p_model_path, temp_dir):
     if G2P_DISABLED:
         pytest.skip('No Pynini found')


### PR DESCRIPTION
In response to an [issue](https://github.com/MontrealCorpusTools/Montreal-Forced-Aligner/issues/234) I stumbled upon when parsing a custom dataset I came up with a fix.

The error occurs when we try to run `check_bracketed` on an empty string `''`. 
Instead of indexing we can use `string.startswith` and `string.endswith`.