### PR TITLE
Textgrid phonetier modification + few parameters changes: allow-downsample, snip-edges

### DIFF
--- a/montreal_forced_aligner/config/basic_train.yaml
+++ b/montreal_forced_aligner/config/basic_train.yaml
@@ -5,6 +5,7 @@ features:
   type: "mfcc"
   use_energy: false
   frame_shift: 10
+  snip_edges: false
 
 training:
   - monophone:

--- a/montreal_forced_aligner/features/config.py
+++ b/montreal_forced_aligner/features/config.py
@@ -57,6 +57,7 @@ class FeatureConfig(object):
         self.fmllr = False
         self.use_energy = False
         self.frame_shift = 10
+        self.snip_edges = False
         self.pitch = False
         self.splice_left_context = 3
         self.splice_right_context = 3
@@ -67,6 +68,7 @@ class FeatureConfig(object):
         return {'type': self.type,
                 'use_energy': self.use_energy,
                 'frame_shift': self.frame_shift,
+                'snip_edges': self.snip_edges,
                 'pitch': self.pitch,
                 'deltas': self.deltas,
                 'lda': self.lda,
@@ -108,8 +110,11 @@ class FeatureConfig(object):
         os.makedirs(path, exist_ok=True)
         path = os.path.join(path, f)
         with open(path, 'w', encoding='utf8') as f:
+            f.write('--{}={}\n'.format('allow-downsample', 'true'))
+            f.write('--{}={}\n'.format('sample-frequency', '16000'))
             f.write('--{}={}\n'.format('use-energy', make_safe(self.use_energy)))
             f.write('--{}={}\n'.format('frame-shift', make_safe(self.frame_shift)))
+            f.write('--{}={}\n'.format('snip-edges', make_safe(self.snip_edges)))
             if extra_params is not None:
                 for k, v in extra_params.items():
                     f.write('--{}={}\n'.format(k, make_safe(v)))

--- a/montreal_forced_aligner/textgrid.py
+++ b/montreal_forced_aligner/textgrid.py
@@ -70,12 +70,13 @@ def ctm_to_textgrid(word_ctm, phone_ctm, out_directory, corpus, dictionary, fram
                 tg = TextGrid(maxTime=maxtime)
                 wordtier = IntervalTier(name='words', maxTime=maxtime)
                 phonetier = IntervalTier(name='phones', maxTime=maxtime)
+                phonetier_len = len(phone_ctm[k][speaker])
                 for interval in v:
                     if maxtime - interval[1] < frameshift:  # Fix rounding issues
                         interval[1] = maxtime
                     wordtier.add(*interval)
-                for interval in phone_ctm[k][speaker]:
-                    if maxtime - interval[1] < frameshift:
+                for j, interval in enumerate(phone_ctm[k][speaker]):
+                    if j == phonetier_len - 1:  # sync last phone boundary to end of audio file
                         interval[1] = maxtime
                     phonetier.add(*interval)
                 tg.append(wordtier)


### PR DESCRIPTION
Hi, here are 3 changes that I think would be nice to integrate.

1. First, I noticed that `textgrid` is inserting empty labels `""` whenever there is a gap between the final label end-time and the end of the audio file. In `textgrid.py` there is this line adjusting the last label end-time to the end of audio (maxtime):
`                    if maxtime - interval[1] < frameshift:  # Fix rounding issues
                        interval[1] = maxtime
`
However it does not correct gaps greater than frameshift, so it still leaves some empty labels.  This is a desirable behaviour for the word tier which doesn't have the equivalent of `sil` or `sp` labels, but for the phone tier this is ambiguous, there cannot be empty labels, it should be either an inserted pause `sp`, silence `sil`, a phoneme or unknown noise `spn`. Consider this result:
      `intervals [41]:
	      xmin = 3.830
	      xmax = 3.880
	      text = "z"
       intervals [42]:
	      xmin = 3.880
	      xmax = 3.9
	      text = ""`
One might think that there is a silence at the end whereas the audio file is actually truncated and terminates in the middle of the phone `z`. For these reasons it is preferable to always extend the final phone boundary to the end of the audio file: 
`                    if j == phonetier_len - 1:  # sync last phone boundary to end of audio file
                        interval[1] = maxtime`

2. The two other changes are about some parameters for the MFCC extraction, 
- using `snip-edges=false` gives more accurate alignment results (in terms of boundary position), and is recommended here: https://groups.google.com/g/kaldi-developers/c/NhdT6nc_Ldc

- using `allow-downsample=true` and `sample-frequency=16000` as default arguments for `compute-mfcc-feats` leaves the downsampling to Kaldi and is more efficient I believe.