### PR TITLE
Add forced sample rate to non-mp file loading process

### DIFF
--- a/montreal_forced_aligner/corpus/acoustic_corpus.py
+++ b/montreal_forced_aligner/corpus/acoustic_corpus.py
@@ -962,6 +962,7 @@ class AcousticCorpusMixin(CorpusMixin, FeatureConfigMixin, metaclass=ABCMeta):
                             relative_path,
                             self.speaker_characters,
                             sanitize_function,
+                            self.sample_frequency
                         )
 
                         self.add_file(file, session)


### PR DESCRIPTION
Without the forced sample rate parameter passing in, the sample rate cannot be adjusted in the non-multiprocessing mode, causing errors in Kaldi processes.