### PR TITLE
Rearrange Dockerfile to halve size of Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,13 @@ FROM condaforge/mambaforge:22.11.1-4 as build
 
 COPY ci/docker_environment.yaml .
 RUN mkdir -p /mfa
-RUN mamba env create -p /env -f docker_environment.yaml && conda clean -afy
-
-COPY . /pkg
-RUN conda run -p /env python -m pip install speechbrain
-RUN conda run -p /env python -m pip install --no-deps /pkg
-
 RUN useradd -ms /bin/bash mfauser
 RUN chown -R mfauser /mfa
-RUN chown -R mfauser /env
+COPY . /pkg
+RUN mamba env create -p /env -f docker_environment.yaml && conda clean -afy && \
+ chown -R mfauser /env
+RUN conda run -p /env python -m pip install speechbrain && \
+ conda run -p /env python -m pip install --no-deps /pkg
 USER mfauser
 ENV MFA_ROOT_DIR=/mfa
 RUN conda run -p /env mfa server init


### PR DESCRIPTION
Thanks for this great tool. I was using your MFA Docker images and noticed that they are quite large.

The step `RUN chown -R mfauser /env` effectively doubles the size of the image since it has its own layer and all the files in /env are different due to user privilege changes. This can be prevented by simply chaining the two operations; the installation of the dependencies and the user privilege changes.

This PR rearranges some steps in the Dockerfile and does these two operations in the same Docker image layer. This reduces the size of the image by about half.

Don't hesitate to modify this PR if there are any issues with it.