### PR TITLE
Fixes bugs for subfolder errors

### DIFF
--- a/montreal_forced_aligner/models.py
+++ b/montreal_forced_aligner/models.py
@@ -143,7 +143,7 @@ class Archive(MfaModel):
             os.makedirs(root_directory, exist_ok=True)
             unpack_archive(source, self.dirname)
             files = [x for x in self.dirname.iterdir()]
-            old_dir_path = self.dirname.joinpath(files[0])
+            old_dir_path = files[0]
             if len(files) == 1 and old_dir_path.is_dir():  # Backwards compatibility
                 for f in old_dir_path.iterdir():
                     f = f.relative_to(old_dir_path)


### PR DESCRIPTION
When the decompressed .zip files contain a top directory, the obtained path is incorrect. 

## Refefence

API of pathlib: https://docs.python.org/3/library/pathlib.html

### Path.iterdir()
When the path points to a directory, yield path objects of the directory contents:

```
>>> p = Path('docs')
>>> for child in p.iterdir(): child
...
PosixPath('docs/conf.py')
PosixPath('docs/_templates')
PosixPath('docs/make.bat')
PosixPath('docs/index.rst')
PosixPath('docs/_build')
PosixPath('docs/_static')
PosixPath('docs/Makefile')
```
The children are yielded in arbitrary order, and the special entries '.' and '..' are not included. If a file is removed from or added to the directory after creating the iterator, whether a path object for that file be included is unspecified.