### PR TITLE
Fix using github token from enviroment

### DIFF
--- a/montreal_forced_aligner/models.py
+++ b/montreal_forced_aligner/models.py
@@ -1667,7 +1667,7 @@ class ModelManager:
         }
         self.token = token
         environment_token = os.environ.get("GITHUB_TOKEN", None)
-        if self.token is not None:
+        if self.token is None:
             self.token = environment_token
         self.synced_remote = False
         self.ignore_cache = ignore_cache


### PR DESCRIPTION
Common sense dictates that token from enviroment should be used only when token is NOT provided with arguments. Current code works exactly the opposite.