### PR TITLE
fixed an item-lost bug when exporting to textgrid

### DIFF
--- a/montreal_forced_aligner/textgrid.py
+++ b/montreal_forced_aligner/textgrid.py
@@ -383,6 +383,7 @@ def construct_textgrid_output(
             if phone_data:
                 process_phone_data()
                 current_file_id = pi_current_file_id
+                phone_data = []
             else:
                 break
         for wi_begin, wi_end, word, wi_speaker_name, wi_file_id in word_intervals:
@@ -417,9 +418,9 @@ def construct_textgrid_output(
         )
         export_textgrid(data, output_path, file_duration, frame_shift, output_format)
         yield output_path
-        word_data = []
-        phone_data = []
-        utterance_data = []
+        # word_data = []
+        # phone_data = []
+        # utterance_data = []
 
 
 def construct_output_path(


### PR DESCRIPTION
There is a item-lost bug in the previous version, which will make every file to lose its first phone and word item in the exported textgrid file.

## Problem

In function `construct_textgrid_output` of file `textgrid.py`, the `while True` loop ends with this:

https://github.com/MontrealCorpusTools/Montreal-Forced-Aligner/blob/76c46a197f7f7d827f33c36bfe0088568294ecc6/montreal_forced_aligner/textgrid.py#L420-L422

These codes empty the three lists, while they are not empty because of these lines:

https://github.com/MontrealCorpusTools/Montreal-Forced-Aligner/blob/76c46a197f7f7d827f33c36bfe0088568294ecc6/montreal_forced_aligner/textgrid.py#L377

https://github.com/MontrealCorpusTools/Montreal-Forced-Aligner/blob/76c46a197f7f7d827f33c36bfe0088568294ecc6/montreal_forced_aligner/textgrid.py#L393

https://github.com/MontrealCorpusTools/Montreal-Forced-Aligner/blob/76c46a197f7f7d827f33c36bfe0088568294ecc6/montreal_forced_aligner/textgrid.py#L406

Emptying them at the ending of a loop will cause a direct data discard.

## Solution

I removed the three lines first, and to avoid the loop becomes an infinite loop, in this `if` block:

https://github.com/MontrealCorpusTools/Montreal-Forced-Aligner/blob/76c46a197f7f7d827f33c36bfe0088568294ecc6/montreal_forced_aligner/textgrid.py#L383-L387

I added a:

`phone_data = []`

These codes were tested and worked well now.