### PR TITLE
Fix acoustic_corpus.py corpus error logging crash

### DIFF
--- a/montreal_forced_aligner/corpus/acoustic_corpus.py
+++ b/montreal_forced_aligner/corpus/acoustic_corpus.py
@@ -933,7 +933,7 @@ class AcousticCorpusMixin(CorpusMixin, FeatureConfigMixin, metaclass=ABCMeta):
                             for e in error_dict[k]:
                                 logger.debug(f"{e.file_name}: {e.error}")
                         else:
-                            logger.debug(", ".join(error_dict[k]))
+                            logger.debug(", ".join(str(error_dict[k])))
                             setattr(self, k, error_dict[k])
 
         except Exception as e:


### PR DESCRIPTION
See https://github.com/MontrealCorpusTools/Montreal-Forced-Aligner/issues/863 for details.