### PR TITLE
Fix alignment fine-tune option and alignment archive path bug

### DIFF
--- a/montreal_forced_aligner/alignment/multiprocessing.py
+++ b/montreal_forced_aligner/alignment/multiprocessing.py
@@ -957,7 +957,7 @@ class FineTuneFunction(KaldiFunction):
                     acoustic_model=self.acoustic_model,
                     lexicon_compiler=self.lexicon_compilers[d.id],
                 )
-                ali_path = job.construct_path(workflow.working_directory, "ali", ".ark", d.name)
+                ali_path = job.construct_path(workflow.working_directory, "ali", "ark", d.name)
                 alignment_archive = AlignmentArchive(ali_path)
                 utterance_query = (
                     session.query(Utterance, SoundFile.sound_file_path)

--- a/montreal_forced_aligner/alignment/pretrained.py
+++ b/montreal_forced_aligner/alignment/pretrained.py
@@ -89,7 +89,7 @@ class PretrainedAligner(TranscriberMixin, TopLevelMfaWorker):
         kw.update(kwargs)
         super().__init__(**kw)
         self.fine_tune = fine_tune
-        self.fine_tune = fine_tune_boundary_tolerance
+        self.fine_tune_boundary_tolerance = fine_tune_boundary_tolerance
         self.final_alignment = True
         self.kalpy_aligner = None
 

--- a/tests/test_commandline_align.py
+++ b/tests/test_commandline_align.py
@@ -444,6 +444,8 @@ def test_align_fine_tune(
         print(result.exc_info)
         raise result.exception
     assert not result.return_value
+    # Regression test for --fine_tune flag
+    assert "Fine tuning alignments..." in result.stderr
 
 
 def test_align_evaluation(


### PR DESCRIPTION
Hello!

This PR fixes two related issues affecting the [`--fine_tune`](https://montreal-forced-aligner.readthedocs.io/en/v3.2.3/user_guide/workflows/alignment.html#cmdoption-mfa-align-fine_tune) functionality:

- **Fine-tuning not triggered:** The `PretrainedAligner.__init__()` method was incorrectly assigning `fine_tune_boundary_tolerance` to `self.fine_tune`, effectively disabling fine-tuning even when the flag was passed. This is now fixed, and a regression test ensures the fine-tuning process is properly invoked.
  The issue has been present since #912 (v3.3.5).

- **Incorrect alignment archive path:** The construction of `.ark` file paths during fine-tuning included an unintended leading dot in the extension (`..ark`), which caused a `FileNotFoundError`.
  Example traceback:

```
"~/.anaconda3/envs/aligner/lib/python3.11/site-packages/montreal_forced_aligner/alignment/multiprocessing.py", line 961, in _run
    alignment_archive = AlignmentArchive(ali_path)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.anaconda3/envs/aligner/lib/python3.11/site-packages/kalpy/gmm/data.py", line 296, in __init__
    raise OSError(f"Specified file does not exist: {file_name}")
OSError: Specified file does not exist: ~/Documents/MFA/test/alignment/ali.spanish_spain_mfa.2..ark 
```
This second issue remained hidden because the fine-tuning was never activated. But the test suite already fails if the `..ark` bug resurfaces, so no extra assertion was added for that specific case.

To confirm that fine-tuning is now active, check that the aligner prints:
```
 INFO     Fine tuning alignments...
```

These changes are minimal and maintain backward compatibility with current usage.