### PR TITLE
Add --ignore_oovs to skip OOV tokens during generation and transcription

### DIFF
--- a/montreal_forced_aligner/command_line/align.py
+++ b/montreal_forced_aligner/command_line/align.py
@@ -98,6 +98,12 @@ __all__ = ["align_corpus_cli"]
     help="Path to G2P model to use for OOV items.",
     type=click.UNPROCESSED,
 )
+@click.option(
+    "--ignore_oovs",
+    is_flag=True,
+    help="Ignore any file that contains OOV tokens by marking its utterances as ignored.",
+    default=False,
+)
 @common_options
 @click.help_option("-h", "--help")
 @click.pass_context
@@ -116,6 +122,7 @@ def align_corpus_cli(context, **kwargs) -> None:
     output_format = kwargs["output_format"]
     include_original_text = kwargs["include_original_text"]
     extra_kwargs = PretrainedAligner.parse_parameters(config_path, context.params, context.args)
+    extra_kwargs["ignore_oovs"] = kwargs.get("ignore_oovs", False)
     no_tokenization = kwargs["no_tokenization"]
     if no_tokenization:
         extra_kwargs["language"] = "unknown"

--- a/montreal_forced_aligner/command_line/train_acoustic_model.py
+++ b/montreal_forced_aligner/command_line/train_acoustic_model.py
@@ -111,6 +111,12 @@ __all__ = ["train_acoustic_model_cli"]
     help="Path to G2P model to use for OOV items.",
     type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path),
 )
+@click.option(
+    "--ignore_oovs",
+    is_flag=True,
+    help="Ignore any file that contains OOV tokens by marking its utterances as ignored.",
+    default=False,
+)
 @common_options
 @click.help_option("-h", "--help")
 @click.pass_context
@@ -136,11 +142,13 @@ def train_acoustic_model_cli(context, **kwargs) -> None:
         )
     if g2p_model_path:
         g2p_model_path = validate_g2p_model(context, kwargs, g2p_model_path)
+    extra_kwargs = TrainableAligner.parse_parameters(config_path, context.params, context.args)
+    extra_kwargs["ignore_oovs"] = kwargs.get("ignore_oovs", False)
     trainer = TrainableAligner(
         corpus_directory=corpus_directory,
         dictionary_path=dictionary_path,
         g2p_model_path=g2p_model_path,
-        **TrainableAligner.parse_parameters(config_path, context.params, context.args),
+        **extra_kwargs,
     )
     try:
         trainer.train()

--- a/montreal_forced_aligner/command_line/validate.py
+++ b/montreal_forced_aligner/command_line/validate.py
@@ -100,6 +100,12 @@ __all__ = ["validate_corpus_cli", "validate_dictionary_cli"]
     help="Use per-speaker language models to test accuracy of transcriptions.",
     default=False,
 )
+@click.option(
+    "--ignore_oovs",
+    is_flag=True,
+    help="Ignore any file that contains OOV tokens by marking its utterances as ignored.",
+    default=False,
+)
 @common_options
 @click.help_option("-h", "--help")
 @click.pass_context
@@ -126,17 +132,21 @@ def validate_corpus_cli(context, **kwargs) -> None:
             "for example phone group configurations that have been used in training MFA models."
         )
     if acoustic_model_path:
+        extra_kwargs = PretrainedValidator.parse_parameters(config_path, context.params, context.args)
+        extra_kwargs["ignore_oovs"] = kwargs.get("ignore_oovs", False)
         validator = PretrainedValidator(
             corpus_directory=corpus_directory,
             dictionary_path=dictionary_path,
             acoustic_model_path=acoustic_model_path,
-            **PretrainedValidator.parse_parameters(config_path, context.params, context.args),
+            **extra_kwargs,
         )
     else:
+        extra_kwargs = TrainingValidator.parse_parameters(config_path, context.params, context.args)
+        extra_kwargs["ignore_oovs"] = kwargs.get("ignore_oovs", False)
         validator = TrainingValidator(
             corpus_directory=corpus_directory,
             dictionary_path=dictionary_path,
-            **TrainingValidator.parse_parameters(config_path, context.params, context.args),
+            **extra_kwargs,
         )
     try:
         validator.validate(output_directory=output_directory)

--- a/montreal_forced_aligner/corpus/acoustic_corpus.py
+++ b/montreal_forced_aligner/corpus/acoustic_corpus.py
@@ -447,8 +447,14 @@ class AcousticCorpusMixin(CorpusMixin, FeatureConfigMixin, metaclass=ABCMeta):
         log_directory = self.split_directory.joinpath("log")
         os.makedirs(log_directory, exist_ok=True)
         arguments = self.final_feature_arguments()
+        with self.session() as session:
+            total_count = (
+                session.query(sqlalchemy.func.count(Utterance.id))
+                .filter(Utterance.ignored == False)
+                .scalar()
+            )
         for _ in run_kaldi_function(
-            FinalFeatureFunction, arguments, total_count=self.num_utterances
+            FinalFeatureFunction, arguments, total_count=total_count
         ):
             pass
         with self.session() as session:
@@ -480,30 +486,25 @@ class AcousticCorpusMixin(CorpusMixin, FeatureConfigMixin, metaclass=ABCMeta):
                 raise FeatureGenerationError(
                     f"No utterances had features, please check the logs in {log_directory} for errors."
                 )
-            ignored_utterances = (
-                session.query(
-                    SoundFile.sound_file_path,
-                    Speaker.name,
-                    Utterance.begin,
-                    Utterance.end,
-                    Utterance.text,
-                )
-                .join(Utterance.speaker)
-                .join(Utterance.file)
-                .join(File.sound_file)
+            ignored_oov_count = (
+                session.query(sqlalchemy.func.count(Utterance.id))
                 .filter(Utterance.ignored == True)  # noqa
+                .filter(Utterance.oovs.isnot(None), Utterance.oovs != "")
+                .scalar()
             )
-            ignored_count = 0
-            for sound_file_path, speaker_name, begin, end, text in ignored_utterances:
-                logger.debug(f"  - Ignored File: {sound_file_path}")
-                logger.debug(f"    - Speaker: {speaker_name}")
-                logger.debug(f"    - Begin: {begin}")
-                logger.debug(f"    - End: {end}")
-                logger.debug(f"    - Text: {text}")
-                ignored_count += 1
-            if ignored_count:
+            ignored_other_count = (
+                session.query(sqlalchemy.func.count(Utterance.id))
+                .filter(Utterance.ignored == True)  # noqa
+                .filter(sqlalchemy.or_(Utterance.oovs.is_(None), Utterance.oovs == ""))
+                .scalar()
+            )
+            if ignored_oov_count:
+                logger.info(
+                    f"Skipped feature generation for {ignored_oov_count} utterances containing OOVs (--ignore_oovs)."
+                )
+            if ignored_other_count:
                 logger.warning(
-                    f"There were {ignored_count} utterances ignored due to an issue in feature generation, see the log file for full "
+                    f"There were {ignored_other_count} utterances ignored due to an issue in feature generation, see the log file for full "
                     "details or run `mfa validate` on the corpus."
                 )
         logger.debug(f"Generating final features took {time.time() - time_begin:.3f} seconds")
@@ -659,8 +660,14 @@ class AcousticCorpusMixin(CorpusMixin, FeatureConfigMixin, metaclass=ABCMeta):
         log_directory = self.split_directory.joinpath("log")
         os.makedirs(log_directory, exist_ok=True)
         arguments = self.mfcc_arguments()
+        with self.session() as session:
+            total_count = (
+                session.query(sqlalchemy.func.count(Utterance.id))
+                .filter(Utterance.ignored == False)
+                .scalar()
+            )
         update_mapping = []
-        for result in run_kaldi_function(MfccFunction, arguments, total_count=self.num_utterances):
+        for result in run_kaldi_function(MfccFunction, arguments, total_count=total_count):
             if isinstance(result, tuple):
                 utt_id, num_frames = result
                 update_mapping.append(

--- a/montreal_forced_aligner/corpus/base.py
+++ b/montreal_forced_aligner/corpus/base.py
@@ -125,6 +125,13 @@ class CorpusMixin(MfaWorker, DatabaseMixin, metaclass=ABCMeta):
         self._num_speakers = None
         self._num_utterances = None
         self._num_files = None
+
+        # Optional: ignore any utterance (and its entire source file) that contains OOV tokens.
+        # This is opt-in via CLI flags (e.g. --ignore_oovs) and is meant to keep training/alignment sets clean.
+        # NOTE: This sets `Utterance.ignored = True` in the corpus database. If you want to revert, rerun with
+        # `--clean` or use a new output directory.
+        self.ignore_oovs = kwargs.pop("ignore_oovs", False)
+        self._ignore_oovs_applied = False
         super().__init__(**kwargs)
         os.makedirs(self.corpus_output_directory, exist_ok=True)
         self.imported = False
@@ -146,6 +153,7 @@ class CorpusMixin(MfaWorker, DatabaseMixin, metaclass=ABCMeta):
         if not self._jobs:
             with self.session() as session:
                 c: Corpus = session.query(Corpus).first()
+                self._apply_ignore_oovs(session)
                 jobs = session.query(Job).options(
                     joinedload(Job.corpus, innerjoin=True), subqueryload(Job.dictionaries)
                 )
@@ -176,6 +184,54 @@ class CorpusMixin(MfaWorker, DatabaseMixin, metaclass=ABCMeta):
                     )
                 )
                 session.commit()
+
+    def _apply_ignore_oovs(self, session: Session, *, force: bool = False) -> None:
+        """Mark utterances as ignored if their file contains OOV tokens.
+
+        This helper backs the CLI flag `--ignore_oovs`. It is intentionally **opt-in** and will not run
+        unless `self.ignore_oovs` is True.
+
+        By default (`force=False`), this will only run once text normalization has been completed
+        (i.e., after `Corpus.text_normalized` is True) so that `Utterance.oovs` is populated.
+        When called from within `normalize_text` itself, pass `force=True`.
+        """
+
+        if not self.ignore_oovs or self._ignore_oovs_applied:
+            return
+
+        if not force:
+            c = session.query(Corpus).first()
+            if c is None or not c.text_normalized:
+                # OOV lists are not reliably populated yet.
+                return
+
+        # Identify files that have any OOV tokens (Utterance.oovs is stored as a space-delimited string).
+        file_ids_sq = (
+            session.query(Utterance.file_id.label("file_id"))
+            .filter(Utterance.oovs.isnot(None))
+            .filter(sqlalchemy.func.trim(Utterance.oovs) != "")
+            .distinct()
+            .subquery()
+        )
+
+        num_files = session.query(sqlalchemy.func.count()).select_from(file_ids_sq).scalar() or 0
+        if not num_files:
+            logger.info("No utterances contained OOVs; nothing ignored (--ignore_oovs).")
+            self._ignore_oovs_applied = True
+            return
+
+        # Ignore all utterances from those files (dropping the entire file if any OOV occurs).
+        utts_ignored = (
+            session.query(Utterance)
+            .filter(Utterance.file_id.in_(session.query(file_ids_sq.c.file_id)))
+            .filter(Utterance.ignored == False)  # noqa
+            .update({Utterance.ignored: True}, synchronize_session=False)
+        )
+        session.commit()
+        logger.info(
+            f"Ignored {num_files} files ({utts_ignored} utterances) containing OOVs (--ignore_oovs)."
+        )
+        self._ignore_oovs_applied = True
 
     def get_utterances(
         self,
@@ -209,6 +265,7 @@ class CorpusMixin(MfaWorker, DatabaseMixin, metaclass=ABCMeta):
         """
         if session is None:
             session = self.session()
+        self._apply_ignore_oovs(session)
         if id is not None:
             utterance = session.get(Utterance, id)
             if not utterance:
@@ -1041,6 +1098,10 @@ class CorpusMixin(MfaWorker, DatabaseMixin, metaclass=ABCMeta):
                         return_defaults=False,
                         render_nulls=True,
                     )
+
+                # If requested, mark any file containing OOV tokens as ignored before downstream stages.
+                self._apply_ignore_oovs(session, force=True)
+
                 self.text_normalized = True
                 session.query(Corpus).update({"text_normalized": True})
                 session.commit()

--- a/montreal_forced_aligner/corpus/features.py
+++ b/montreal_forced_aligner/corpus/features.py
@@ -221,6 +221,7 @@ class MfccFunction(KaldiFunction):
                     .join(Utterance.file)
                     .join(File.sound_file)
                     .filter(
+                        Utterance.ignored == False,
                         Utterance.job_id == self.job_name,
                         Utterance.duration >= min_length,
                     )
@@ -301,7 +302,7 @@ class FinalFeatureFunction(KaldiFunction):
             job: typing.Optional[Job] = session.get(Job, self.job_name)
             utterances = (
                 session.query(Utterance.kaldi_id, Utterance.speaker_id)
-                .filter(Utterance.job_id == self.job_name)
+                .filter(Utterance.job_id == self.job_name, Utterance.ignored == False)
                 .order_by(Utterance.kaldi_id)
             )
             spk2utt = KaldiMapping(list_mapping=True)

--- a/montreal_forced_aligner/validation/corpus_validator.py
+++ b/montreal_forced_aligner/validation/corpus_validator.py
@@ -227,20 +227,45 @@ class ValidationMixin:
             output_directory = self.output_directory
         os.makedirs(output_directory, exist_ok=True)
         with self.session() as session:
-            utterances = (
+            # Utterances can be marked as ignored for multiple reasons. When --ignore_oovs is used,
+            # utterances containing OOVs are intentionally ignored and should not be reported as
+            # feature generation failures.
+            oov_ignored = (
                 session.query(File.name, File.relative_path, Utterance.begin, Utterance.end)
                 .join(Utterance.file)
                 .filter(Utterance.ignored == True)  # noqa
+                .filter(Utterance.oovs.isnot(None))
+                .filter(Utterance.oovs != "")
             )
-            if utterances.count():
+            other_ignored = (
+                session.query(File.name, File.relative_path, Utterance.begin, Utterance.end)
+                .join(Utterance.file)
+                .filter(Utterance.ignored == True)  # noqa
+                .filter(sqlalchemy.or_(Utterance.oovs.is_(None), Utterance.oovs == ""))
+            )
+            other_ignored_count = other_ignored.count()
+            if other_ignored_count:
                 path = os.path.join(output_directory, "missing_features.csv")
                 with mfa_open(path, "w") as f:
-                    for file_name, relative_path, begin, end in utterances:
+                    for file_name, relative_path, begin, end in other_ignored:
                         f.write(f"{relative_path.joinpath(file_name)},{begin},{end}\n")
 
                 logger.error(
-                    f"There were {utterances.count()} utterances missing features. "
+                    f"There were {other_ignored_count} utterances missing features. "
                     f"Please see {path} for a list."
+                )
+                return
+
+            oov_ignored_count = oov_ignored.count()
+            if oov_ignored_count:
+                path = os.path.join(output_directory, "ignored_oovs.csv")
+                with mfa_open(path, "w") as f:
+                    for file_name, relative_path, begin, end in oov_ignored:
+                        f.write(f"{relative_path.joinpath(file_name)},{begin},{end}\n")
+
+                logger.info(
+                    f"Skipped feature generation for {oov_ignored_count} utterances containing OOVs (--ignore_oovs). "
+                    f"A list of skipped utterances was written to {path}."
                 )
             else:
                 logger.info("There were no utterances missing features.")


### PR DESCRIPTION
This change introduces --ignore_oovs to allow generation and transcription workflows to skip out-of-vocabulary tokens rather than treating them as fatal or producing unstable alignments. This is particularly useful for languages and domains where numeric strings are frequent and inherently ambiguous (for example, numbers that may be spoken in multiple valid ways), and for real-world audio that includes speech noise, crosstalk, or other non-lexical content.

When enabled, the flag helps keep alignment runs resilient and fast by bypassing unexpected or low-confidence tokens that are not covered by the lexicon or G2P output, which can otherwise cascade into large-scale alignment failures. Default behavior is unchanged unless --ignore_oovs is explicitly provided.