### PR TITLE
fix: Remove extra parameter in function call

### DIFF
--- a/montreal_forced_aligner/online/alignment.py
+++ b/montreal_forced_aligner/online/alignment.py
@@ -82,7 +82,6 @@ def align_utterance_online(
     utterance.transcript = tokenize_utterance_text(
         utterance.transcript,
         lexicon_compiler,
-        lexicon_compiler,
         tokenizer,
         g2p_model,
         language=acoustic_model.language,


### PR DESCRIPTION
The lexicon_compiler was being passed twice causing an error in the function call.